### PR TITLE
Updated library SimpleImpersonation 2.0.1 to 3.0.0. 

### DIFF
--- a/Frends.Community.PDFWriter/Frends.Community.PDFWriter.csproj
+++ b/Frends.Community.PDFWriter/Frends.Community.PDFWriter.csproj
@@ -53,8 +53,8 @@
     <Reference Include="PdfSharp.Charting-gdi, Version=1.50.5147.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
       <HintPath>..\packages\PDFsharp-MigraDoc-gdi.1.50.5147\lib\net20\PdfSharp.Charting-gdi.dll</HintPath>
     </Reference>
-    <Reference Include="SimpleImpersonation, Version=2.0.1.27158, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SimpleImpersonation.2.0.1\lib\net40-Client\SimpleImpersonation.dll</HintPath>
+    <Reference Include="SimpleImpersonation, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleImpersonation.3.0.0\lib\net45\SimpleImpersonation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Frends.Community.PDFWriter/PDFWriterTask.cs
+++ b/Frends.Community.PDFWriter/PDFWriterTask.cs
@@ -117,10 +117,7 @@ namespace Frends.Community.PDFWriter
                 else
                 {
                     var domainAndUserName = GetDomainAndUserName(options.UserName);
-                    using(Impersonation.LogonUser(domainAndUserName[0], domainAndUserName[1], options.Password, LogonType.NewCredentials))
-                    {
-                        pdfRenderer.PdfDocument.Save(fileName);
-                    }
+                    Impersonation.RunAsUser(new UserCredentials(domainAndUserName[0], domainAndUserName[1], options.Password), LogonType.NewCredentials, () => pdfRenderer.PdfDocument.Save(fileName));
                 }
 
                 return new Output { Success = true, FileName = fileName };

--- a/Frends.Community.PDFWriter/packages.config
+++ b/Frends.Community.PDFWriter/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="PDFsharp-MigraDoc-GDI" version="1.50.5147" targetFramework="net452" />
-  <package id="SimpleImpersonation" version="2.0.1" targetFramework="net461" />
+  <package id="SimpleImpersonation" version="3.0.0" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -176,3 +176,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.6.0 | System.ComponentModel is now used instead of Frends.Tasks.Attributes |
 | 1.7.0 | Add support for headers and footers. Update MigraDoc version. |
 | 1.8.0 | Add support for tables. |
+| 1.8.1 | Task now support both SimpleImpersonation 2 and 3. |

--- a/nuspec/Frends.Community.PDFWriter.nuspec
+++ b/nuspec/Frends.Community.PDFWriter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Frends.Community.PDFWriter</id>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <title>Frends Community PDF Writer</title>
     <authors>HiQ Finland</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Updated library SimpleImpersonation 2.0.1 to 3.0.0. Changed method call LogonUser to RunAsUser since method deprecation.

This is the same change as in FCOM-253 branch for DownloadFile-task.